### PR TITLE
(#85) fix: br generation bug

### DIFF
--- a/ast/match.go
+++ b/ast/match.go
@@ -9,6 +9,15 @@ type Pattern struct {
 	S Stat
 }
 
+func (p *Pattern) IsBr() bool {
+	switch p.S.(type) {
+	case *BreakStat:
+		return true
+	default:
+		return false
+	}
+}
+
 type Match struct {
 	matchExpr   Expr
 	patterns    []*Pattern
@@ -50,7 +59,9 @@ func (m *Match) Codegen(c *Context) llvm.Value {
 
 		// each patternBlock at least have to do
 		pattern.S.Codegen(c)
-		c.Builder.CreateBr(leave)
+		if !pattern.IsBr() {
+			c.Builder.CreateBr(leave)
+		}
 
 		patternBlock.MoveAfter(prevPattern)
 		prevPattern = patternBlock

--- a/ast/match.go
+++ b/ast/match.go
@@ -9,8 +9,8 @@ type Pattern struct {
 	S Stat
 }
 
-func (p *Pattern) IsBr() bool {
-	switch p.S.(type) {
+func IsBr(stat Stat) bool {
+	switch stat.(type) {
 	case *BreakStat:
 		return true
 	default:
@@ -59,7 +59,7 @@ func (m *Match) Codegen(c *Context) llvm.Value {
 
 		// each patternBlock at least have to do
 		pattern.S.Codegen(c)
-		if !pattern.IsBr() {
+		if !IsBr(pattern.S) {
 			c.Builder.CreateBr(leave)
 		}
 


### PR DESCRIPTION
## What do you do?

Before generating `br` instruction for `match` statement, add checking for the statement of the pattern, if the pattern statement is something will generate `br` instruction, we don't generate `br` for `match` statement.

problem: `match` block can't work with a `break` statement.
reason: two `br` instruction is invalid to compile(both `match` & `break` generated one)
solution:
- add a check before creating `br` for `match`
- create check function
