### PR TITLE
add: main function would compile to a binary

### DIFF
--- a/example/main.elz
+++ b/example/main.elz
@@ -1,0 +1,3 @@
+fn main() {
+  let a = 1
+}

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -188,12 +188,14 @@ impl Visitor {
         let mut context = FunctionContext::from(new_fn);
         let basic_block = self.context.append_basic_block(&new_fn, "entry");
         self.visit_statements(&mut context, statements, &basic_block);
-        let end_of_fn = new_fn
-            .get_last_basic_block()
-            .expect("missing basic block in function");
-        self.builder.position_at_end(&end_of_fn);
-        self.builder
-            .build_return(Some(&self.context.i32_type().const_int(1 as u64, true)));
+        if name == "main" {
+            let end_of_fn = new_fn
+                .get_last_basic_block()
+                .expect("missing basic block in function");
+            self.builder.position_at_end(&end_of_fn);
+            self.builder
+                .build_return(Some(&self.context.i32_type().const_int(0 as u64, true)));
+        }
         self.functions.insert(name, context);
     }
     fn visit_statements(


### PR DESCRIPTION
- problem: we want to use `fn main()` represent a binary
- solution: When the function name is `main`, I set its type to `() -> i32` in particle, if `main` type is not `() -> ()` would panic the compiler process
